### PR TITLE
handle excess content

### DIFF
--- a/lib/pg_siphon/message.ex
+++ b/lib/pg_siphon/message.ex
@@ -104,6 +104,7 @@ defmodule PgSiphon.Message do
     [%PgSiphon.Message{payload: message, type: "p", length: length} | decode(rest)]
   end
 
+  # We cannot assume
   def decode(excess) do
     Logger.debug(
       "Unknown message cannot be parsed [#{inspect(excess, bin: :as_binary, limit: :infinity)}]"

--- a/lib/pg_siphon/message.ex
+++ b/lib/pg_siphon/message.ex
@@ -35,14 +35,14 @@ defmodule PgSiphon.Message do
     [%PgSiphon.Message{payload: message, type: "0", length: length} | decode(rest)]
   end
 
-  def decode(<<66, length::integer-size(32), rest::binary>>) do
+  def decode(<<66, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     # Logger.debug(inspect(rest, bin: :as_binaries, limit: :infinity))
 
     <<message::binary-size(length - 4), rest::binary>> = rest
     [%PgSiphon.Message{payload: message, type: "B", length: length} | decode(rest)]
   end
 
-  def decode(<<67, length::integer-size(32), rest::binary>>) do
+  def decode(<<67, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     length = length - 4
     <<_desc_type::binary-size(1), message::binary-size(length - 1), rest::binary>> = rest
 
@@ -50,77 +50,66 @@ defmodule PgSiphon.Message do
     [%PgSiphon.Message{payload: message, type: "C", length: length} | decode(rest)]
   end
 
-  def decode(<<68, length::integer-size(32), rest::binary>>) do
+  # Possibly wrong?
+  def decode(<<68, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     length = length - 4
     # desc_type -> 'S' to describe a prepared statement; or 'P' to describe a portal.
     <<_desc_type::binary-size(1), message::binary-size(length - 1), rest::binary>> = rest
-
-    # Ignoring desc type for now
     [%PgSiphon.Message{payload: message, type: "D", length: length} | decode(rest)]
   end
 
-  def decode(<<69, length::integer-size(32), rest::binary>>) do
+  def decode(<<69, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "E", length: length} | decode(rest)]
   end
 
-  def decode(<<72, length::integer-size(32), rest::binary>>) do
+  def decode(<<72, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
-
     [%PgSiphon.Message{payload: message, type: "H", length: length} | decode(rest)]
   end
 
-  def decode(<<80, length::integer-size(32), rest::binary>>) do
-    # Logger.debug(inspect(length))
-
+  def decode(<<80, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
-    # Logger.debug(inspect(message))
-    # Logger.debug(inspect(rest, bin: :as_binaries, limit: :infinity))
-
     [%PgSiphon.Message{payload: message, type: "P", length: length} | decode(rest)]
   end
 
-  def decode(<<81, length::integer-size(32), rest::binary>>) do
+  def decode(<<81, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "Q", length: length} | decode(rest)]
   end
 
-  def decode(<<83, length::integer-size(32), rest::binary>>) do
+  def decode(<<83, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "S", length: length} | decode(rest)]
   end
 
-  def decode(<<88, length::integer-size(32), rest::binary>>) do
+  def decode(<<88, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "X", length: length} | decode(rest)]
   end
 
-  def decode(<<102, length::integer-size(32), rest::binary>>) do
+  def decode(<<102, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "f", length: length} | decode(rest)]
   end
 
-  def decode(<<112, length::integer-size(32), rest::binary>>) do
+  def decode(<<112, length::integer-size(32), rest::binary>>) when (length - 4) <= byte_size(rest) do
     <<message::binary-size(length - 4), rest::binary>> = rest
 
     [%PgSiphon.Message{payload: message, type: "p", length: length} | decode(rest)]
   end
 
-  def decode(unknown) when byte_size(unknown) >= 4 do
+  def decode(excess) do
     Logger.debug(
-      "Unknown message cannot be parsed [#{inspect(unknown, bin: :as_binary, limit: :infinity)}]"
+      "Unknown message cannot be parsed [#{inspect(excess, bin: :as_binary, limit: :infinity)}]"
     )
 
-    []
-  end
-
-  def decode(_) do
-    []
+    [%PgSiphon.Message{payload: excess, type: "U", length: byte_size(excess)}]
   end
 
   def valid_type?(type), do: Map.has_key?(@fe_msg_id, type)

--- a/lib/pg_siphon/monitoring_server.ex
+++ b/lib/pg_siphon/monitoring_server.ex
@@ -88,17 +88,15 @@ defmodule PgSiphon.MonitoringServer do
     {:noreply, %State{count: state.count + 1}}
   end
 
-  defp perform_log_message(message_frame, %State{recording: true, filter_message_types: []}) do
-    message_frame
-    |> decode()
+  defp perform_log_message(decoded_messages, %State{recording: true, filter_message_types: []}) do
+    decoded_messages
     |> log_message_frame()
 
     :ok
   end
 
-  defp perform_log_message(message_frame, %State{recording: true, filter_message_types: filter_message_types}) do
-    message_frame
-    |> decode()
+  defp perform_log_message(decoded_messages, %State{recording: true, filter_message_types: filter_message_types}) do
+    decoded_messages
     |> Enum.filter(fn %PgSiphon.Message{type: type} ->
       Enum.member?(filter_message_types, type)
     end)

--- a/lib/pg_siphon/query_server.ex
+++ b/lib/pg_siphon/query_server.ex
@@ -82,9 +82,9 @@ defmodule PgSiphon.QueryServer do
 
   # Implementation
 
-  defp perform_message_insert(message, %State{table: table, recording: true} = state) do
-    decoded_messages = message
-    |> decode()
+  defp perform_message_insert(decoded_messages, %State{table: table, recording: true} = state) do
+    # decoded_messages = message
+    # |> decode()
 
     Enum.each(decoded_messages, fn %Message{payload: payload, type: type, length: length} ->
       case :ets.lookup(table, payload) do

--- a/lib/pg_siphon/services_supervisor.ex
+++ b/lib/pg_siphon/services_supervisor.ex
@@ -8,8 +8,8 @@ defmodule PgSiphon.ServicesSupervisor do
   def init(:ok) do
     children = [
       PgSiphon.QueryServer,
-      PgSiphon.ProxyServer,
-      PgSiphon.MonitoringServer
+      PgSiphon.MonitoringServer,
+      PgSiphon.ProxyServer
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/test/pg_siphon/message_test.exs
+++ b/test/pg_siphon/message_test.exs
@@ -60,4 +60,41 @@ defmodule PgSiphon.MessageTest do
     message_frame = <<83, 0, 0, 0, 4>>
     assert [%PgSiphon.Message{payload: "", type: "S", length: 4}] = PgSiphon.Message.decode(message_frame)
   end
+
+  test "decode/1 with unknown" do
+    message_frame = <<0, 83, 69, 76, 69, 67, 84, 32, 42, 32, 70, 82>>
+    assert [
+      %PgSiphon.Message{
+        payload: <<0, 83, 69, 76, 69, 67, 84, 32, 42, 32,
+          70, 82>>,
+        type: "U",
+        length: 12
+      }
+    ] = PgSiphon.Message.decode(message_frame)
+  end
+
+  test "parse/1 with extras" do
+    message_frame = <<80, 0, 0, 0, 28, 0, 83, 69, 76, 69, 67, 84, 32, 42, 32, 70, 82, 79, 77, 32, 110, 97, 109, 101, 115, 59, 0, 0, 0, 68, 0, 0, 0, 6, 83, 0, 72, 0, 0, 0, 4, 80, 0, 0, 0, 28, 0, 83, 69, 76, 69, 67, 84, 32, 42, 32, 70, 82>>
+    assert [
+      %PgSiphon.Message{
+        payload: <<0, 83, 69, 76, 69, 67, 84, 32, 42, 32,
+          70, 82, 79, 77, 32, 110, 97, 109, 101, 115, 59, 0,
+          0, 0>>,
+        type: "P",
+        length: 28
+      },
+      %PgSiphon.Message{
+        payload: <<0>>,
+        type: "D",
+        length: 2
+      },
+      %PgSiphon.Message{payload: "", type: "H", length: 4},
+      %PgSiphon.Message{
+        payload: <<80, 0, 0, 0, 28, 0, 83, 69, 76, 69, 67,
+          84, 32, 42, 32, 70, 82>>,
+        type: "U",
+        length: 17
+      }
+    ] = PgSiphon.Message.decode(message_frame)
+  end
 end


### PR DESCRIPTION
mtu limits means messages can be cut off, if they cant be parsed we need to handle them appropriately using buffers