### PR TITLE
task: remove unused query server

### DIFF
--- a/lib/pg_siphon/proxy_server.ex
+++ b/lib/pg_siphon/proxy_server.ex
@@ -5,7 +5,6 @@ defmodule PgSiphon.ProxyServer do
 
   @name :proxy_server
 
-  alias PgSiphon.QueryServer
   alias PgSiphon.MonitoringServer
   alias PgSiphon.ActiveConnectionsServer
 
@@ -209,7 +208,8 @@ defmodule PgSiphon.ProxyServer do
   end
 
   defp dispatch_full_frames(decoded_messages) do
-    spawn(fn -> QueryServer.add_message(decoded_messages) end)
+    # Do we still need this?
+    # spawn(fn -> QueryServer.add_message(decoded_messages) end)
     spawn(fn -> MonitoringServer.log_message(decoded_messages) end)
   end
 end


### PR DESCRIPTION
this pr is to allow pausing - however it already exists on the monitoring server.

no further work needed, but we can remove query server no longer needed, and the heavy lifting is on the pg_siphon_management project for this work